### PR TITLE
fix(transform): add missing ThisExpression

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -227,7 +227,17 @@ export const transform = (node: InputNode, context: Context): OutputNode => {
       const isOptional = type === 'SafePropertyRead';
       const { name, receiver } = node as ng.PropertyRead | ng.SafePropertyRead;
       if (getNgType(receiver) === 'ImplicitReceiver') {
-        return _c<b.Identifier>('Identifier', { name });
+        return receiver.span.start === receiver.span.end
+          ? _c<b.Identifier>('Identifier', { name })
+          : _c<b.MemberExpression>('MemberExpression', {
+              computed: false,
+              object: _c<b.ThisExpression>('ThisExpression', {}, receiver.span),
+              property: _c<b.Identifier>(
+                'Identifier',
+                { name },
+                { start: receiver.span.end + 1, end: node.span.end },
+              ),
+            });
       }
       const memberExpression = _c<
         b.MemberExpression | b.OptionalMemberExpression

--- a/tests/trasnform.test.ts
+++ b/tests/trasnform.test.ts
@@ -23,14 +23,16 @@ import {
 
 describe.each`
   beforeType            | afterType                     | input                       | action   | binding  | simple   | interpolation
-  ${'BindingPipe'}      | ${'NGPipeExpression'}         | ${' a | b : c '}            | ${false} | ${true}  | ${false} | ${true}
   ${'Binary'}           | ${'BinaryExpression'}         | ${' 0 - 1 '}                | ${true}  | ${true}  | ${true}  | ${true}
   ${'Binary'}           | ${'LogicalExpression'}        | ${' a && b '}               | ${true}  | ${true}  | ${true}  | ${true}
   ${'Binary'}           | ${'UnaryExpression'}          | ${' - 1 '}                  | ${true}  | ${true}  | ${true}  | ${true}
+  ${'BindingPipe'}      | ${'NGPipeExpression'}         | ${' a | b : c '}            | ${false} | ${true}  | ${false} | ${true}
+  ${'Chain'}            | ${'NGChainedExpression'}      | ${' a ; b '}                | ${true}  | ${false} | ${false} | ${false}
   ${'Conditional'}      | ${'ConditionalExpression'}    | ${' a ? 1 : 2 '}            | ${true}  | ${true}  | ${true}  | ${true}
   ${'EmptyExpr'}        | ${'NGEmptyExpression'}        | ${''}                       | ${true}  | ${true}  | ${true}  | ${false}
   ${'FunctionCall'}     | ${'CallExpression'}           | ${' a ( 1 ) ( 2 ) '}        | ${true}  | ${true}  | ${true}  | ${true}
   ${'KeyedRead'}        | ${'MemberExpression'}         | ${' a [ b ] '}              | ${true}  | ${true}  | ${true}  | ${true}
+  ${'KeyedWrite'}       | ${'AssignmentExpression'}     | ${' a [ b ] = 1 '}          | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralArray'}     | ${'ArrayExpression'}          | ${' [ 1 ] '}                | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralMap'}       | ${'ObjectExpression'}         | ${' { "a" : 1 } '}          | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralMap'}       | ${'ObjectExpression'}         | ${' { a : 1 } '}            | ${true}  | ${true}  | ${true}  | ${true}
@@ -40,21 +42,19 @@ describe.each`
   ${'LiteralPrimitive'} | ${'NumericLiteral'}           | ${' ( 1 ) '}                | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralPrimitive'} | ${'NumericLiteral'}           | ${' 1 '}                    | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralPrimitive'} | ${'StringLiteral'}            | ${' "hello" '}              | ${true}  | ${true}  | ${true}  | ${true}
-  ${'MethodCall'}       | ${'CallExpression'}           | ${' a ( 1 , 2 ) '}          | ${true}  | ${true}  | ${true}  | ${true}
   ${'MethodCall'}       | ${'CallExpression'}           | ${' a . b ( 1 , 2 ) '}      | ${true}  | ${true}  | ${true}  | ${true}
+  ${'MethodCall'}       | ${'CallExpression'}           | ${' a ( 1 , 2 ) '}          | ${true}  | ${true}  | ${true}  | ${true}
   ${'NonNullAssert'}    | ${'TSNonNullExpression'}      | ${' x ! '}                  | ${true}  | ${true}  | ${true}  | ${true}
   ${'PrefixNot'}        | ${'UnaryExpression'}          | ${' ! x '}                  | ${true}  | ${true}  | ${true}  | ${true}
   ${'PropertyRead'}     | ${'Identifier'}               | ${' ( ( a ) ) '}            | ${true}  | ${true}  | ${true}  | ${true}
   ${'PropertyRead'}     | ${'Identifier'}               | ${' a '}                    | ${true}  | ${true}  | ${true}  | ${true}
   ${'PropertyRead'}     | ${'Identifier'}               | ${' a // hello '}           | ${true}  | ${true}  | ${true}  | ${true}
   ${'PropertyRead'}     | ${'MemberExpression'}         | ${' a . b '}                | ${true}  | ${true}  | ${true}  | ${true}
+  ${'PropertyWrite'}    | ${'AssignmentExpression'}     | ${' a . b = 1 '}            | ${true}  | ${false} | ${false} | ${false}
+  ${'PropertyWrite'}    | ${'AssignmentExpression'}     | ${' a = 1 '}                | ${true}  | ${false} | ${false} | ${false}
   ${'Quote'}            | ${'NGQuotedExpression'}       | ${' javascript : void(0) '} | ${false} | ${true}  | ${true}  | ${false}
   ${'SafeMethodCall'}   | ${'OptionalCallExpression'}   | ${' a ?. b ( ) '}           | ${true}  | ${true}  | ${true}  | ${true}
   ${'SafePropertyRead'} | ${'OptionalMemberExpression'} | ${' a ?. b '}               | ${true}  | ${true}  | ${true}  | ${true}
-  ${'PropertyWrite'}    | ${'AssignmentExpression'}     | ${' a = 1 '}                | ${true}  | ${false} | ${false} | ${false}
-  ${'PropertyWrite'}    | ${'AssignmentExpression'}     | ${' a . b = 1 '}            | ${true}  | ${false} | ${false} | ${false}
-  ${'KeyedWrite'}       | ${'AssignmentExpression'}     | ${' a [ b ] = 1 '}          | ${true}  | ${true}  | ${true}  | ${true}
-  ${'Chain'}            | ${'NGChainedExpression'}      | ${' a ; b '}                | ${true}  | ${false} | ${false} | ${false}
 `('$input ($beforeType -> $afterType)', fields => {
   const { beforeType, afterType, input } = fields;
 

--- a/tests/trasnform.test.ts
+++ b/tests/trasnform.test.ts
@@ -50,6 +50,7 @@ describe.each`
   ${'PropertyRead'}     | ${'Identifier'}               | ${' a '}                    | ${true}  | ${true}  | ${true}  | ${true}
   ${'PropertyRead'}     | ${'Identifier'}               | ${' a // hello '}           | ${true}  | ${true}  | ${true}  | ${true}
   ${'PropertyRead'}     | ${'MemberExpression'}         | ${' a . b '}                | ${true}  | ${true}  | ${true}  | ${true}
+  ${'PropertyRead'}     | ${'MemberExpression'}         | ${' this . a '}             | ${true}  | ${true}  | ${true}  | ${true}
   ${'PropertyWrite'}    | ${'AssignmentExpression'}     | ${' a . b = 1 '}            | ${true}  | ${false} | ${false} | ${false}
   ${'PropertyWrite'}    | ${'AssignmentExpression'}     | ${' a = 1 '}                | ${true}  | ${false} | ${false} | ${false}
   ${'Quote'}            | ${'NGQuotedExpression'}       | ${' javascript : void(0) '} | ${false} | ${true}  | ${true}  | ${false}


### PR DESCRIPTION
input

```js
this.a
```

before

```json5
{ type: "Identifier", name: "a" }
```

after

```json5
{
  type: "MemberExpression",
  object: { type: "ThisExpression" },
  property: { type: "Identifier", name: "a" }
}
```