### PR TITLE
fix(peer-deps): Angular 9.0.6+ is not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "3.7.5"
   },
   "peerDependencies": {
-    "@angular/compiler": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+    "@angular/compiler": ">= 6.0.0 < 9.0.6"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
There are breaking changes in Angular 9.0.6 and 9.1.0. The support for ^9.0.6 will be skipped since the effort to add support for it does not seem to be worth, so the next supported version will be 9.1.0+ (#187).