### PR TITLE
fix(transform): correct chained optional expression with computed properties

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -170,20 +170,18 @@ export const transform = (
     }
     case 'KeyedRead': {
       const { obj, key } = node as ng.KeyedRead;
-      const tObj = _t<b.Expression>(obj);
       const tKey = _t<b.Expression>(key);
-      return _c<b.MemberExpression>(
-        'MemberExpression',
+      return _transformReceiverAndName(
+        obj,
+        tKey,
         {
           computed: true,
-          object: tObj,
-          property: tKey,
+          optional: false,
         },
         {
-          start: _getOuterStart(tObj),
           end: node.span.end, // ]
+          hasParentParens: isInParentParens,
         },
-        { hasParentParens: isInParentParens },
       );
     }
     case 'LiteralArray': {

--- a/tests/trasnform.test.ts
+++ b/tests/trasnform.test.ts
@@ -36,6 +36,8 @@ describe.each`
   ${'FunctionCall'}     | ${'CallExpression'}           | ${' ( a ) ( 1 , 2 ) '}      | ${true}  | ${true}  | ${true}  | ${true}
   ${'FunctionCall'}     | ${'CallExpression'}           | ${' a ( 1 ) ( 2 ) '}        | ${true}  | ${true}  | ${true}  | ${true}
   ${'KeyedRead'}        | ${'MemberExpression'}         | ${' a [ b ] '}              | ${true}  | ${true}  | ${true}  | ${true}
+  ${'KeyedRead'}        | ${'OptionalMemberExpression'} | ${' a ?. b [ c ] '}         | ${true}  | ${true}  | ${true}  | ${true}
+  ${'KeyedRead'}        | ${'OptionalMemberExpression'} | ${' a ?. b () [ c ] '}      | ${true}  | ${true}  | ${true}  | ${true}
   ${'KeyedWrite'}       | ${'AssignmentExpression'}     | ${' a [ b ] = 1 '}          | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralArray'}     | ${'ArrayExpression'}          | ${' [ 1 ] '}                | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralMap'}       | ${'ObjectExpression'}         | ${' { "a" : 1 } '}          | ${true}  | ${true}  | ${true}  | ${true}


### PR DESCRIPTION
Fixes #191

input

```js
a ?. b [ c ]
a ?. b () [ c ]
```

before

```js
{ type: "MemberExpression" }
{ type: "MemberExpression" }
```

after

```js
{ type: "OptionalMemberExpression" }
{ type: "OptionalMemberExpression" }
```