### PR TITLE
fix(transform): handle ThisExpression correctly

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -168,6 +168,11 @@ export const transform = (
         { hasParentParens: isInParentParens },
       );
     }
+    case 'ImplicitReceiver': {
+      return _c<b.ThisExpression>('ThisExpression', {}, node.span, {
+        hasParentParens: isInParentParens,
+      });
+    }
     case 'KeyedRead': {
       const { obj, key } = node as ng.KeyedRead;
       const tObj = _t<b.Expression>(obj);
@@ -488,13 +493,11 @@ export const transform = (
     props: { computed: boolean; optional: boolean },
     { end = _getOuterEnd(tName), hasParentParens = false } = {},
   ) {
+    // implicit `this`
     if (receiver.span.start >= receiver.span.end) {
       return tName;
     }
-    const tReceiver =
-      getNgType(receiver) === 'ImplicitReceiver'
-        ? _c<b.ThisExpression>('ThisExpression', {}, receiver.span)
-        : _t<b.Expression>(receiver);
+    const tReceiver = _t<b.Expression>(receiver);
     const isOptionalReceiver = _isOptionalReceiver(tReceiver);
     return _c<b.OptionalMemberExpression | b.MemberExpression>(
       props.optional || isOptionalReceiver

--- a/tests/trasnform.test.ts
+++ b/tests/trasnform.test.ts
@@ -37,6 +37,7 @@ describe.each`
   ${'FunctionCall'}     | ${'CallExpression'}           | ${' a ( 1 ) ( 2 ) '}        | ${true}  | ${true}  | ${true}  | ${true}
   ${'KeyedRead'}        | ${'MemberExpression'}         | ${' a [ b ] '}              | ${true}  | ${true}  | ${true}  | ${true}
   ${'KeyedWrite'}       | ${'AssignmentExpression'}     | ${' a [ b ] = 1 '}          | ${true}  | ${true}  | ${true}  | ${true}
+  ${'ImplicitReceiver'} | ${'ThisExpression'}           | ${' this '}                 | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralArray'}     | ${'ArrayExpression'}          | ${' [ 1 ] '}                | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralMap'}       | ${'ObjectExpression'}         | ${' { "a" : 1 } '}          | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralMap'}       | ${'ObjectExpression'}         | ${' { a : 1 } '}            | ${true}  | ${true}  | ${true}  | ${true}
@@ -46,6 +47,7 @@ describe.each`
   ${'LiteralPrimitive'} | ${'NumericLiteral'}           | ${' ( 1 ) '}                | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralPrimitive'} | ${'NumericLiteral'}           | ${' 1 '}                    | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralPrimitive'} | ${'StringLiteral'}            | ${' "hello" '}              | ${true}  | ${true}  | ${true}  | ${true}
+  ${'MethodCall'}       | ${'CallExpression'}           | ${' a ( this ) '}           | ${true}  | ${true}  | ${true}  | ${true}
   ${'MethodCall'}       | ${'CallExpression'}           | ${' a . b ( 1 , 2 ) '}      | ${true}  | ${true}  | ${true}  | ${true}
   ${'MethodCall'}       | ${'CallExpression'}           | ${' a ( 1 , 2 ) '}          | ${true}  | ${true}  | ${true}  | ${true}
   ${'MethodCall'}       | ${'OptionalCallExpression'}   | ${' a ?. b . c ( ) '}       | ${true}  | ${true}  | ${true}  | ${true}


### PR DESCRIPTION
Fixes #192

input

```js
this
a(this)
```

before

```js
// error: Unexpected node ImplicitReceiver
// hang
```

after

```js
{ type: "ThisExpression" }
{ type: "CallExpression" }
```