### PR TITLE
fix(transform): handle implicit `this` correctly

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -354,10 +354,7 @@ export const transform = (
         'Identifier',
         { name },
         { start: nameEnd - name.length, end: nameEnd },
-        // special case
-        receiver.span.start === receiver.span.end
-          ? { hasParentParens: isInParentParens }
-          : {},
+        _isImplicitThis(receiver) ? { hasParentParens: isInParentParens } : {},
       );
       return _transformReceiverAndName(
         receiver,
@@ -491,8 +488,7 @@ export const transform = (
     props: { computed: boolean; optional: boolean },
     { end = _getOuterEnd(tName), hasParentParens = false } = {},
   ) {
-    // implicit `this`
-    if (receiver.span.start >= receiver.span.end) {
+    if (_isImplicitThis(receiver)) {
       return tName;
     }
     const tReceiver = _t<b.Expression>(receiver);
@@ -522,6 +518,10 @@ export const transform = (
 
   function _findBackChar(regex: RegExp, index: number) {
     return findBackChar(regex, index, context.text);
+  }
+
+  function _isImplicitThis(n: ng.AST): boolean {
+    return n.span.start >= n.span.end;
   }
 
   function _isOptionalReceiver(n: OutputNode): boolean {

--- a/tests/trasnform.test.ts
+++ b/tests/trasnform.test.ts
@@ -50,6 +50,7 @@ describe.each`
   ${'LiteralPrimitive'} | ${'NumericLiteral'}           | ${' 1 '}                    | ${true}  | ${true}  | ${true}  | ${true}
   ${'LiteralPrimitive'} | ${'StringLiteral'}            | ${' "hello" '}              | ${true}  | ${true}  | ${true}  | ${true}
   ${'MethodCall'}       | ${'CallExpression'}           | ${' a ( this ) '}           | ${true}  | ${true}  | ${true}  | ${true}
+  ${'MethodCall'}       | ${'CallExpression'}           | ${' a ( b) '}               | ${true}  | ${true}  | ${true}  | ${true}
   ${'MethodCall'}       | ${'CallExpression'}           | ${' a . b ( 1 , 2 ) '}      | ${true}  | ${true}  | ${true}  | ${true}
   ${'MethodCall'}       | ${'CallExpression'}           | ${' a ( 1 , 2 ) '}          | ${true}  | ${true}  | ${true}  | ${true}
   ${'MethodCall'}       | ${'OptionalCallExpression'}   | ${' a ?. b . c ( ) '}       | ${true}  | ${true}  | ${true}  | ${true}


### PR DESCRIPTION
Fixes #195

input

```js
a( b)
```

before

```js
// hang
```

after

```js
{ type: "CallExpression" }
```