### PR TITLE
fix(transform-microsyntax): handle implicit `$implicit` correctly

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import { Parser } from '@angular/compiler/src/expression_parser/parser';
 import { RawNGComment, RawNGSpan } from './types';
 
 const NG_PARSE_FAKE_LOCATION = 'angular-estree-parser';
-const NG_PARSE_TEMPLATE_BINDINGS_FAKE_PREFIX = 'NgEstreeParser';
+export const NG_PARSE_TEMPLATE_BINDINGS_FAKE_PREFIX = 'NgEstreeParser';
 const NG_PARSE_FAKE_ABSOLUTE_OFFSET = 0;
 const NG_PARSE_SHARED_PARAMS: readonly [string, number] = [
   NG_PARSE_FAKE_LOCATION,

--- a/tests/__snapshots__/transform-microsyntax.test.ts.snap
+++ b/tests/__snapshots__/transform-microsyntax.test.ts.snap
@@ -188,6 +188,24 @@ NGMicrosyntaxKey { name: "b" }
     |       ^
 `;
 
+exports[`" as b " 1`] = `
+NGMicrosyntax { body: ["NGMicrosyntaxAs"] }
+> 1 |  as b 
+    |  ^^^^
+--------------------------------------------------------------------------------
+NGMicrosyntaxAs { key: "NGMicrosyntaxKey", alias: "NGMicrosyntaxKey" }
+> 1 |  as b 
+    |  ^^^^
+--------------------------------------------------------------------------------
+NGMicrosyntaxKey { name: "$implicit" }
+> 1 |  as b 
+    |  ^
+--------------------------------------------------------------------------------
+NGMicrosyntaxKey { name: "b" }
+> 1 |  as b 
+    |     ^
+`;
+
 exports[`" let \\"\\\\\\"\\" " 1`] = `
 NGMicrosyntax { body: ["NGMicrosyntaxLet"] }
 > 1 |  let "\\"" 

--- a/tests/transform-microsyntax.test.ts
+++ b/tests/transform-microsyntax.test.ts
@@ -8,6 +8,7 @@ test.each`
   ${' let hero = hello '}           | ${['NGMicrosyntaxLet']}
   ${' let hero of heroes '}         | ${['NGMicrosyntaxLet', 'NGMicrosyntaxKeyedExpression']}
   ${' let hero ; of : heroes '}     | ${['NGMicrosyntaxLet', 'NGMicrosyntaxKeyedExpression']}
+  ${' as b '}                       | ${['NGMicrosyntaxAs']}
   ${' a '}                          | ${['NGMicrosyntaxExpression']}
   ${' a as b '}                     | ${['NGMicrosyntaxExpression']}
   ${' a , b '}                      | ${['NGMicrosyntaxExpression', 'NGMicrosyntaxKey']}


### PR DESCRIPTION
Fixes #198
