### PR TITLE
feat(types): export NGNode and NGMicrosyntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ function parse(
   return ast;
 }
 
+export { NGMicrosyntax, NGNode };
+
 export function parseBinding(input: string): NGNode {
   return parse(input, parseNgBinding);
 }


### PR DESCRIPTION
Importing the `NGNode` type would really help us when updating Prettier to do JSDoc typecheck on the language-js code in <https://github.com/prettier/prettier/pull/8759>.

Right now we import `NGNode` like this in our new `ast.d.ts` module:

```ts
import * as NGTree from "angular-estree-parser/lib/types";
```

But I think it would be better if we could import directly from `angular-estree-parser`.

I think it could also be useful if someone could import `NGMicrosyntax` directly from `angular-estree-parser` as well.

This proposal will export `NGMicrosyntax` and `NGTree` from `index.d.ts`.

/cc @fisker